### PR TITLE
Bump SocketRocket version to 0.4.x

### DIFF
--- a/Phoenix-ObjC.podspec
+++ b/Phoenix-ObjC.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
     'Phoenix-ObjC' => ['Pod/Assets/*.png']
   }
 
-  s.dependency 'SocketRocket', '~> 0.3.1-beta2'
+  s.dependency 'SocketRocket', '~> 0.4.0'
 end

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ## Requirements
 
-SocketRocket - 0.3.1-beta2
+SocketRocket - 0.4.x
 
 ## Installation
 


### PR DESCRIPTION
Bumping SocketRocket to 0.4 stable.

**question:** current spec version is `0.2.1`, should I send another PR to bump the cocoapods file to `0.2.2` or `0.3.0`?
