### PR TITLE
Update library to work with current version of Phoenix

### DIFF
--- a/Pod/Classes/Phoenix.h
+++ b/Pod/Classes/Phoenix.h
@@ -37,6 +37,7 @@
 @interface PhoenixChannel : NSObject
 
 typedef void(^HandleEventBlock)(id message);
+typedef void(^HandleReplyBlock)(id reply);
 
 @property (nonatomic, strong, readonly) NSString *topic;
 @property (nonatomic, strong, readonly) NSDictionary *payload;
@@ -47,7 +48,7 @@ typedef void(^HandleEventBlock)(id message);
 - (BOOL)join;
 - (BOOL)leave;
 
-- (void)sendEvent:(NSString*)event payload:(id)payload;
+- (void)sendEvent:(NSString*)event payload:(id)payload onReply:(HandleReplyBlock)handleReplyBlock;
 
 - (void)on:(NSString*)event handleEventBlock:(HandleEventBlock)handleEventBlock;
 

--- a/Pod/Classes/Phoenix.h
+++ b/Pod/Classes/Phoenix.h
@@ -14,7 +14,7 @@
 @interface Phoenix : NSObject
 
 @property (nonatomic, strong, readonly) NSURL *url;
-@property (nonatomic, assign) id<PhoenixDelegate> delegate;
+@property (nonatomic, weak) id<PhoenixDelegate> delegate;
 
 - (instancetype)initWithURL:(NSURL*)url;
 

--- a/Pod/Classes/Phoenix.m
+++ b/Pod/Classes/Phoenix.m
@@ -98,11 +98,12 @@
 #pragma mark - Helpers
 
 - (void)send:(NSString*)topic event:(NSString*)event payload:(id)payload {
-
+	static int ref = 0;
     NSDictionary *message = @{
                               @"topic": topic,
                               @"event": event,
                               @"payload": payload ?: [NSNull null]
+                              @"ref": [@(ref++) stringValue]
                               };
 
     NSData *data = [NSJSONSerialization dataWithJSONObject:message options:0 error:nil];

--- a/Pod/Classes/Phoenix.m
+++ b/Pod/Classes/Phoenix.m
@@ -215,6 +215,7 @@
         HandleReplyBlock replyBlock = _replyHandlers[ref];
         if (replyBlock) {
             replyBlock(message);
+            [_replyHandlers removeObjectForKey:ref];
         }
     }
 }

--- a/Pod/Classes/Phoenix.m
+++ b/Pod/Classes/Phoenix.m
@@ -70,7 +70,7 @@
     _channels[channel.topic] = channel;
 
     // Joins channel
-    [self send:channel.topic event:@"join" payload:channel.payload];
+    [self send:channel.topic event:@"phx_join" payload:channel.payload];
 
     return YES;
 }
@@ -84,7 +84,7 @@
     [_channels removeObjectForKey:channel.topic];
 
     // Leaves channel
-    [self send:channel.topic event:@"leave" payload:nil];
+    [self send:channel.topic event:@"phx_leave" payload:nil];
 
     return YES;
 }

--- a/Pod/Classes/Phoenix.m
+++ b/Pod/Classes/Phoenix.m
@@ -14,6 +14,7 @@
 
 @property (nonatomic, strong) SRWebSocket *webSocket;
 @property (nonatomic, assign) BOOL isOpen;
+@property (nonatomic, assign) NSInteger ref;
 
 @property (nonatomic, strong) NSMutableDictionary *channels;
 
@@ -98,12 +99,11 @@
 #pragma mark - Helpers
 
 - (void)send:(NSString*)topic event:(NSString*)event payload:(id)payload {
-	static int ref = 0;
     NSDictionary *message = @{
                               @"topic": topic,
                               @"event": event,
-                              @"payload": payload ?: [NSNull null]
-                              @"ref": [@(ref++) stringValue]
+                              @"payload": payload ?: [NSNull null],
+                              @"ref": [@(_ref++) stringValue]
                               };
 
     NSData *data = [NSJSONSerialization dataWithJSONObject:message options:0 error:nil];


### PR DESCRIPTION
I'm sorry I haven't submitted this earlier, but here goes:

This updates the lib to work with the current version of Phoenix. For example, it's now called `phx_join` instead of `join`, and also all messages now need a unique number called `ref`.

Some crashes related to non-nilled pointers were fixed as well.

Thanks for the library!
